### PR TITLE
Remove the upper version limit for SciPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "openai-clip",
     "torchvision>=0.2.1,<0.20.0",
     "pillow>=8.3.2,<10.1.0", 
-    "scipy>=1.0.1,<1.11.0",
+    "scipy>=1.0.1",
     "absl-py",
     "google-auth-oauthlib<1.1,>=0.5",
     "grpcio",


### PR DESCRIPTION
SciPy is now at 1.15.0 and several other packages have moved beyond this 1.11.0 dependency. Given that it seems to build just fine using 1.15.0, i propose removing the arbitrary upper bound.